### PR TITLE
Feature/music api

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -45,6 +45,7 @@ class Server(Application):
             QuotesView(self),
             EventSubView(self),
             MbtiView(self),
+            PlayerView(self),
         ]
         middleware: list[Middleware] = [
             Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"]),

--- a/core/bots.py
+++ b/core/bots.py
@@ -29,7 +29,7 @@ from discord.ext import commands
 from twitchio.ext import commands as tcommands
 
 from .config import config
-from .constants import MBTI_TYPES
+from .constants import MBTI_TYPES, TIME_GUILD
 
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class DiscordBot(commands.Bot):
         if config["DEBUG"]["enabled"] is True:
             return
 
-        guild: discord.Guild = self.get_guild(859565527343955998)  # type: ignore
+        guild: discord.Guild = self.get_guild(TIME_GUILD)  # type: ignore
         role: discord.Role = guild.get_role(LIVE_ROLE_ID)  # type: ignore
         subbed: discord.Role = guild.get_role(SUBBED_ROLE_ID)  # type: ignore
 
@@ -121,7 +121,7 @@ class DiscordBot(commands.Bot):
         if config["DEBUG"]["enabled"] is True:
             return
 
-        if before.guild.id != 859565527343955998:
+        if before.guild.id != TIME_GUILD:
             return
 
         subbed: discord.Role | None = after.guild.get_role(SUBBED_ROLE_ID)
@@ -151,7 +151,7 @@ class DiscordBot(commands.Bot):
             await after.remove_roles(role, reason="Stopped streaming on Twitch")
 
     def mbti_count(self) -> dict[str, int]:
-        guild: discord.Guild | None = self.get_guild(859565527343955998)
+        guild: discord.Guild | None = self.get_guild(TIME_GUILD)
         assert guild is not None
 
         roles: Sequence[discord.Role] = guild.roles

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,4 +1,7 @@
-__all__ = ("MBTI_TYPES", "TIMEZONES")
+from .config import config
+
+
+__all__ = ("MBTI_TYPES", "TIMEZONES", "TIME_GUILD")
 
 
 MBTI_TYPES: list[str] = [
@@ -20,6 +23,7 @@ MBTI_TYPES: list[str] = [
     "INFP",
 ]
 
+
 TIMEZONES: list[str] = [
     "US/Pacific",
     "US/Eastern",
@@ -33,3 +37,6 @@ TIMEZONES: list[str] = [
     "Brazil/East",
     "Asia/Kolkata",
 ]
+
+
+TIME_GUILD: int = config["GENERAL"]["guild_id"]

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -61,8 +61,17 @@ class Database:
 
         return code
 
-    async def fetch_user(self, token: str) -> None:
-        ...
+    async def fetch_user(self, token: str) -> UserModel | None:
+        assert self.pool
+
+        query: str = """SELECT * FROM users WHERE token = $1"""
+        async with self.pool.acquire() as connection:
+            row = await connection.fetchrow(query, token)
+
+        if not row:
+            return None
+
+        return UserModel(record=row)
 
     async def refresh_or_create_user(self, *, twitch_id: int, state: str) -> UserModel:
         assert self.pool

--- a/example.config.toml
+++ b/example.config.toml
@@ -24,6 +24,7 @@ stream_refs_id = 874734169622716437
 announcements_id = 862800502848749609
 announcements_webhook = ""
 music_webhook = ""
+guild_id = 859565527343955998
 
 [TIME_SUBS]
 events = ["stream.online", "channel.channel_points_custom_reward_redemption.add", "channel.raid"]

--- a/extensions/discord/music.py
+++ b/extensions/discord/music.py
@@ -196,8 +196,11 @@ class Music(commands.Cog):
         elif loaded and payload.original:  # type: ignore
             original: wavelink.Playable = payload.original
 
+            requester: twitchio.User | None = getattr(original, "twitch_user", None)
+            requested: str = f"@{requester.name}" if requester else "Bot AutoPlay"
+
             channel: twitchio.Channel = self.bot.tbot.get_channel("timeenjoyed")  # type: ignore
-            await channel.send(f"Now Playing: {payload.track} requested by @{original.twitch_user.name}")  # type: ignore
+            await channel.send(f"Now Playing: {payload.track} requested by: {requested}")  # type: ignore
             return
 
         # At this point we are playing from Discord not Twitch...

--- a/extensions/twitch/general.py
+++ b/extensions/twitch/general.py
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
 import logging
 import zoneinfo
 from datetime import datetime
@@ -133,7 +132,7 @@ class General(commands.Cog):
 
         user: twitchio.User | discord.User | discord.Member | None = None
         if quote["source"] == "discord":
-            guild: discord.Guild = self.bot.dbot.get_guild(859565527343955998)  # type: ignore
+            guild: discord.Guild = self.bot.dbot.get_guild(core.TIME_GUILD)  # type: ignore
             user = guild.get_member(quote["speaker"]) or await self.bot.dbot.fetch_user(quote["speaker"])
         else:
             try:

--- a/extensions/twitch/music.py
+++ b/extensions/twitch/music.py
@@ -209,7 +209,8 @@ class Music(commands.Cog):
                 f"Current: {current}, "
                 f"Position: {time_}, "
                 f"Requester: {requester}, "
-                f"AutoPlay: {player.autoplay}, "
+                f"AutoPlay: {player.autoplay.name}, "
+                f"Queue: {len(player.queue)}, "
                 f"AutoQueue: {len(player.auto_queue)} "
             )
         )

--- a/extensions/twitch/music.py
+++ b/extensions/twitch/music.py
@@ -33,7 +33,7 @@ class Music(commands.Cog):
             return
 
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             return
@@ -53,7 +53,7 @@ class Music(commands.Cog):
             return
 
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             return
@@ -82,7 +82,7 @@ class Music(commands.Cog):
             return
 
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             return
@@ -108,15 +108,19 @@ class Music(commands.Cog):
             url: str = core.config["GENERAL"]["music_webhook"]
             webhook: discord.Webhook = discord.Webhook.from_url(url=url, session=session)
 
-            requester: twitchio.User = current.twitch_user  # type: ignore
-            await webhook.send(content=msg, avatar_url=requester.profile_image, username=requester.display_name)
+            requester: twitchio.User | None = getattr(current, "twitch_user", None)
+
+            if requester:
+                await webhook.send(content=msg, avatar_url=requester.profile_image, username=requester.display_name)
+            else:
+                await webhook.send(content=msg, username="Bot AutoPlay")
 
         await ctx.reply("Sent this song to discord!")
 
     @commands.command(aliases=["nowplaying", "current", "currentsong", "song"])
     async def playing(self, ctx: commands.Context) -> None:
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             return
@@ -135,8 +139,12 @@ class Music(commands.Cog):
                 time_ = "Live Stream"
 
             current: wavelink.Playable = player.current
+
+            requester: twitchio.User | None = getattr(current, "twitch_user", None)
+            requested: str = f"@{requester.name}" if requester else "Bot AutoPlay"
+
             await ctx.reply(
-                f"Currently playing {current} by {current.author} requested by @{current.twitch_user.name} [{time_}]"  # type: ignore
+                f"Currently playing {current} by {current.author} requested by: {requested} [{time_}]"  # type: ignore
             )
 
     @commands.command(aliases=["pause", "resume"])
@@ -145,7 +153,7 @@ class Music(commands.Cog):
             return
 
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             return
@@ -173,7 +181,7 @@ class Music(commands.Cog):
             return
 
         player: wavelink.Player | None
-        player = wavelink.Pool.get_node().get_player(859565527343955998)
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
 
         if not player:
             await ctx.reply("There currently is no player connected.")
@@ -194,12 +202,15 @@ class Music(commands.Cog):
 
         await ctx.reply(
             (
+                f"Playing?: {player.playing}, "
                 f"Paused: {player.paused}, "
                 f"Volume: {player.volume}, "
                 f"Ping: {player.ping}ms, "
                 f"Current: {current}, "
                 f"Position: {time_}, "
-                f"Requester: {requester}"
+                f"Requester: {requester}, "
+                f"AutoPlay: {player.autoplay}, "
+                f"AutoQueue: {len(player.auto_queue)} "
             )
         )
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,4 +1,5 @@
 from .eventsub import EventSub as EventSubView
 from .mbti import Mbti as MbtiView
+from .music import Player as PlayerView
 from .oauth import OAuth as OAuthView
 from .quotes import Quotes as QuotesView

--- a/routes/music.py
+++ b/routes/music.py
@@ -1,0 +1,228 @@
+"""Copyright 2023 TimeEnjoyed <https://github.com/TimeEnjoyed/>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import wavelink
+from starlette.authentication import requires
+from starlette.responses import JSONResponse, Response
+
+import core
+from api import View, route
+
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+    from api import Server
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class Player(View):
+    def __init__(self, app: Server) -> None:
+        self.app = app
+
+    @route("/info", methods=["GET"])
+    async def get_player(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        try:
+            no_track: bool = bool(int(request.query_params.get("no_track", 0)))
+        except ValueError:
+            no_track = True
+
+        data: dict[str, Any] = {
+            "volume": player.volume,
+            "paused": player.paused,
+            "position": player.position,
+            "ping": player.ping,
+            "queue": len(player.queue),
+            "auto_queue": len(player.auto_queue),
+            "current": player.current.raw_data if player.current and not no_track else None,
+        }
+
+        return JSONResponse(data, status_code=200)
+
+    @route("/current", methods=["GET"])
+    async def get_current_track(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        if not player.current:
+            return Response(status_code=204)
+
+        return JSONResponse(player.current.raw_data, status_code=200)
+
+    @route("/queue", methods=["GET"])
+    async def player_queue(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        queue = [track.raw_data for track in player.queue]
+        auto_queue = [track.raw_data for track in player.auto_queue]
+
+        data = {
+            "queue": queue,
+            "auto_queue": auto_queue,
+        }
+        return JSONResponse(data, status_code=200)
+
+    @route("/controls/volume", methods=["PATCH"])
+    @requires("moderator")
+    async def set_player_volume(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        try:
+            data: dict[str, Any] = await request.json()
+        except Exception as e:
+            logger.debug('Unable to parse JSON in ROUTE "player/controls/volume": %s', e, exc_info=True)
+            return JSONResponse({"error": "Could not parse JSON."}, status_code=400)
+
+        if not data:
+            return JSONResponse({"error": "No data was provided."}, status_code=400)
+
+        try:
+            volume: int = int(data["volume"])
+        except ValueError:
+            return JSONResponse({"error": "Invalid volume value provided."}, status_code=400)
+        except KeyError:
+            return JSONResponse({"error": 'Missing the "volume" key.'}, status_code=400)
+
+        new: int = max(5, min(volume, 100))
+        old: int = player.volume
+        await player.set_volume(new)
+
+        to_return: dict[str, Any] = {
+            "volume": new,
+            "previous": old,
+            "user": {
+                "id": request.user.model.uid,
+                "discord_id": request.user.model.discord_id,
+                "twitch_id": request.user.model.twitch_id,
+            },
+        }
+
+        self.app.tbot.run_event("api_player_volume", to_return)
+        return JSONResponse(to_return, status_code=200)
+
+    @route("/controls/pause", methods=["PATCH"])
+    @requires("moderator")
+    async def pause_player(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        await player.pause(not player.paused)
+
+        to_return: dict[str, Any] = {
+            "paused": player.paused,
+            "user": {
+                "id": request.user.model.uid,
+                "discord_id": request.user.model.discord_id,
+                "twitch_id": request.user.model.twitch_id,
+            },
+        }
+
+        self.app.tbot.run_event("api_player_pause", to_return)
+        return JSONResponse(to_return, status_code=200)
+
+    @route("/controls/skip", methods=["PATCH"])
+    @requires("moderator")
+    async def skip_track(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        await player.skip(force=True)
+
+        to_return: dict[str, Any] = {
+            "user": {
+                "id": request.user.model.uid,
+                "discord_id": request.user.model.discord_id,
+                "twitch_id": request.user.model.twitch_id,
+            },
+        }
+
+        self.app.tbot.run_event("api_player_skip", to_return)
+        return JSONResponse(to_return, status_code=200)
+
+    @route("/controls/play", methods=["POST"])
+    @requires("moderator")
+    async def play_track(self, request: Request) -> Response:
+        player: wavelink.Player | None
+        player = wavelink.Pool.get_node().get_player(core.TIME_GUILD)
+
+        if not player:
+            return JSONResponse({"error": "No player is currently active."}, status_code=404)
+
+        try:
+            data: dict[str, Any] = await request.json()
+        except Exception as e:
+            logger.debug('Unable to parse JSON in ROUTE "player/controls/play": %s', e, exc_info=True)
+            return JSONResponse({"error": "Could not parse JSON."}, status_code=400)
+
+        if not data:
+            return JSONResponse({"error": "No data was provided."}, status_code=400)
+
+        try:
+            search: str = str(data["track"])
+        except KeyError:
+            return JSONResponse({"error": 'Missing the "track" key.'}, status_code=400)
+
+        tracks: wavelink.Search = await wavelink.Playable.search(search, source="ytmsearch")
+        if not tracks:
+            return JSONResponse({"error": f"No tracks were found with query: {search}."}, status_code=422)
+
+        track: wavelink.Playable = tracks[0]
+        player.queue.put(track)
+        started: bool = False
+
+        if not player.playing:
+            started = True
+            await player.play(player.queue.get())
+
+        to_return: dict[str, Any] = {
+            "track": track.raw_data,
+            "started": started,
+            "user": {
+                "id": request.user.model.uid,
+                "discord_id": request.user.model.discord_id,
+                "twitch_id": request.user.model.twitch_id,
+            },
+        }
+
+        self.app.tbot.run_event("api_player_play", to_return)
+        return JSONResponse(to_return, status_code=200)

--- a/types_/config.py
+++ b/types_/config.py
@@ -46,6 +46,7 @@ class General(TypedDict):
     announcements_id: int
     announcements_webhook: str
     music_webhook: str
+    guild_id: int
 
 
 class EventSubs(TypedDict):


### PR DESCRIPTION
Adds routes for controlling the Stream Music Player.

**Routes:**
- `player/info` - GET
  - General player info including the current track, volume, paused state etc
  - Can be used with the `?no_track=1` query parameter to retrieve info minus the track.
  - Returns: `{"volume": int, "paused": bool, "position": int, "ping": int, "queue": int, "auto_queue": int, "current": TRACK_OBJECT or None}`
- `player/current` - GET
  - The currently playing TRACK_OBJECT `200` or `204` if None is playing.
- `player/queue` - GET
  - Track data for every track in the queue and auto_queue.
- `player/controls/volume` - PATCH (Moderator Scope Required)
  - Set the player volume.
  - Example: `{"volume": 50}`
  - Returns: `{"volume": int, "old": int, "user": ...}`
- `player/controls/pause` - PATCH (Moderator Scope Required)
  - Set the player pause state.
  - Returns: `{"paused": bool, "user": ...}`
- `player/controls/skip` - PATCH (Moderator Scope Required)
  - Returns: `{"user": ...}`
- `player/controls/play` - POST (Moderator Scope Required)
  - Example: `{"track": "Ocean Drive Duke Dumont"}`
  - Returns: `{"track": TRACK_OBJECT, "started": bool (Whether the track started playing == True or track was queued == False), "user": ...}`

Various small fixes including moving the guild ID to a config entry and making it a constant.
Various small fixes to allow the bot to play via AutoPlay on Twitch.